### PR TITLE
Fix build for C++20 and above

### DIFF
--- a/include/asio_stream_compressor/detail/compressor_statistics.h
+++ b/include/asio_stream_compressor/detail/compressor_statistics.h
@@ -37,11 +37,7 @@ public:
    */
   value_slice reset() noexcept
   {
-#if __cplusplus < 202002L
-    static const auto RELAXED = std::memory_order::memory_order_relaxed;
-#else
     static const auto RELAXED = std::memory_order_relaxed;
-#endif
     value_slice slice;
     slice.tx_bytes_total = tx_bytes_total.exchange(0, RELAXED);
     slice.tx_bytes_compressed = tx_bytes_compressed.exchange(0, RELAXED);

--- a/include/asio_stream_compressor/detail/compressor_statistics.h
+++ b/include/asio_stream_compressor/detail/compressor_statistics.h
@@ -37,7 +37,11 @@ public:
    */
   value_slice reset() noexcept
   {
+#if __cplusplus < 202002L
     static const auto RELAXED = std::memory_order::memory_order_relaxed;
+#else
+    static const auto RELAXED = std::memory_order_relaxed;
+#endif
     value_slice slice;
     slice.tx_bytes_total = tx_bytes_total.exchange(0, RELAXED);
     slice.tx_bytes_compressed = tx_bytes_compressed.exchange(0, RELAXED);


### PR DESCRIPTION
std::memory_order::memory_order_relaxed was renamed to std::memory_order::relaxed in C++20

see https://en.cppreference.com/w/cpp/atomic/memory_order