### PR TITLE
Fix compilation with boost 1.87.0 (asio v1.33.0+)

### DIFF
--- a/include/asio_stream_compressor/detail/write_operation.h
+++ b/include/asio_stream_compressor/detail/write_operation.h
@@ -107,7 +107,10 @@ public:
 private:
   void encode_data()
   {
-    for (auto& in : buffers_) {
+    auto buffers_begin = asio::buffer_sequence_begin(buffers_);
+    auto buffers_end   = asio::buffer_sequence_end(buffers_);
+    for (auto it = buffers_begin; it != buffers_end; ++it) {
+      auto& in = *it;
       ZSTD_inBuffer in_buf {in.data(), in.size(), 0};
       input_length_ += in.size();
 
@@ -142,7 +145,7 @@ private:
   ZSTD_outBuffer get_free_buffer()
   {
     auto buf_sequence = core_.write_buf_.prepare(ZSTD_DStreamOutSize());
-    auto buf = buf_sequence.begin();
+    auto buf = asio::buffer_sequence_begin(buf_sequence);
     return ZSTD_outBuffer {buf->data(), buf->size(), 0};
   }
 


### PR DESCRIPTION
mutable_buffers_1 and const_buffers_1 were removed (https://github.com/boostorg/asio/commit/534a48c0d54132f3042b923ee3da0d360c84d207) so we can't call .begin() and .end() on a single buffer, we should use asio::buffer_sequence_begin()/asio::buffer_sequence_end() functions instead.